### PR TITLE
Make payments work with Python 2.7

### DIFF
--- a/shoop_checkoutfi/payment_method.py
+++ b/shoop_checkoutfi/payment_method.py
@@ -24,6 +24,7 @@ TEMPLATE = """
 
 
 def flatten_unicode(string):
+    string = force_text(string)
     return force_text(unicodedata.normalize("NFKD", string).encode("ascii", "ignore"))
 
 


### PR DESCRIPTION
Make sure string passed to unicodedata.normalize is unicode
not str
